### PR TITLE
Support for a GIGPATH environment variable (but default to ~/gig)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# GIGPATH environment variable
+
+By default, the scripts use `~/gig` for the data and repositories. When setting the `GIGPATH` environment variable, this can be overridden.

--- a/scripts/g8os_grid_installer82.sh
+++ b/scripts/g8os_grid_installer82.sh
@@ -34,10 +34,10 @@ if [ -e /proc/version ] && grep -q Microsoft /proc/version; then
   # Windows subsystem 4 linux
   WINDOWSUSERNAME=`ls -ail /mnt/c/Users/ | grep drwxrwxrwx | grep -v Public | grep -v Default | grep -v '\.\.'`
   WINDOWSUSERNAME=${WINDOWSUSERNAME##* }
-  GIGHOME=/mnt/c/Users/${WINDOWSUSERNAME}/gig
+  GIGHOME=${GIGPATH:-/mnt/c/Users/${WINDOWSUSERNAME}/gig}
 else
   # Native Linux or MacOSX
-  GIGHOME=~/gig
+  GIGHOME=${GIGPATH:-~/gig}
 fi
 
 echo "Installing grid dependencies"

--- a/scripts/js_builder82_zerotier.sh
+++ b/scripts/js_builder82_zerotier.sh
@@ -32,10 +32,10 @@ if [ -e /proc/version ] && grep -q Microsoft /proc/version; then
   # Windows subsystem 4 linux
   WINDOWSUSERNAME=`ls -ail /mnt/c/Users/ | grep drwxrwxrwx | grep -v Public | grep -v Default | grep -v '\.\.'`
   WINDOWSUSERNAME=${WINDOWSUSERNAME##* }
-  GIGHOME=/mnt/c/Users/${WINDOWSUSERNAME}/gig
+  GIGHOME=${GIGPATH:-/mnt/c/Users/${WINDOWSUSERNAME}/gig}
 else
   # Native Linux or MacOSX
-  GIGHOME=~/gig
+  GIGHOME=${GIGPATH:-~/gig}
 fi
 mkdir -p ${GIGHOME}/data > /tmp/lastcommandoutput.txt 2>&1
 valid


### PR DESCRIPTION
This is the same concept as in golang, where there is a GOPATH environment variable but it defaults to ~/go