### PR TITLE
Mac installer fix

### DIFF
--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -55,7 +55,7 @@ dockerrun() {
 
     # mount optvar/data to all platforms except for windows to avoid fsync mongodb error
     # related: https://docs.mongodb.com/manual/administration/production-notes/#fsync-on-directories
-    if ! grep -q Microsoft /proc/version; then
+    if [ -e /proc/version ] &&  ! grep -q Microsoft /proc/version; then
         mounted_volumes="$mounted_volumes \
             -v ${GIGDIR}/data/:/optvar/data \
         "
@@ -170,7 +170,7 @@ container() {
 }
 
 # alias docker for docker.exe for windows subsystem(WSL) linux because docker isn't supported natively on WSL
-if grep -q Microsoft /proc/version; then
+if [ -e /proc/version ] &&  grep -q Microsoft /proc/version; then
     docker() {
         docker.exe "$@"
     }

--- a/jsenv.sh
+++ b/jsenv.sh
@@ -37,7 +37,7 @@ if [ "$(uname)" = "Darwin" ]; then
     export HOMEDIR=~
     export GIGDIR=${GIGDIR:-~/gig}
 
-elif grep -q Microsoft /proc/version; then
+elif [ -e /proc/version ] && grep -q Microsoft /proc/version; then
     # Windows subsystem 4 linux
     WINDOWSUSERNAME=$(ls -ail /mnt/c/Users/ | grep drwxrwxrwx | grep -v Public | grep -v Default | grep -v '\.\.')
     WINDOWSUSERNAME=${WINDOWSUSERNAME##* }

--- a/jsinit.sh
+++ b/jsinit.sh
@@ -146,6 +146,7 @@ main() {
 
     echo "[+] downloading generic environment file"
     curl -s https://raw.githubusercontent.com/Jumpscale/developer/$GIGDEVELOPERBRANCH/jsenv.sh?$RANDOM > ~/.jsenv.sh
+    sed -i "/export JSENV/a export GIGDIR='${GIGDIR}'" ~/.jsenv.sh
     curl -s https://raw.githubusercontent.com/Jumpscale/developer/$GIGDEVELOPERBRANCH/jsenv-functions.sh?$RANDOM > /tmp/.jsenv-functions.sh
     . /tmp/.jsenv-functions.sh
 

--- a/scripts9/js_builder_base9.sh
+++ b/scripts9/js_builder_base9.sh
@@ -135,6 +135,10 @@ installzerotier() {
     container "apt-get install gpgv2 -y"
     container "curl -s 'https://pgp.mit.edu/pks/lookup?op=get&search=0x1657198823E52A61' | gpg --import"
     container "curl -s https://install.zerotier.com/ | bash || true"
+    # Due to permission changes in OSX Docker + Lowering privileges in zerotier, we need to manually set permissions for tun module
+    if [ "$(uname)" = "Darwin" ]; then
+        container "chmod 666 /dev/net/tun"
+    fi
 }
 
 cleanup() {


### PR DESCRIPTION
#### What this PR resolves:
Fix issues with installer on mac

#### Changes proposed in this PR:

- check for /proc/version existence before greping it because it isn't exist on mac
- change permissions of /dev/net/tun device to fix zero tier error #61 
- export GIGDIR inside .jsenv 


**Version**:  9.1.0

**Fixes**: #61 
