### PR TITLE
Fix installing core9 

### DIFF
--- a/scripts9/js_builder_base9.sh
+++ b/scripts9/js_builder_base9.sh
@@ -116,7 +116,7 @@ installjs9() {
     container rsync -rv /opt/code/github/jumpscale/developer/files_guest/ /
 
     echo "[+]   installing jumpscale core9"
-    container pip3 install -e /opt/code/github/jumpscale/core9
+    container "cd /opt/code/github/jumpscale/core9;bash install.sh"
 
     echo "[+]   installing binaries files"
     container 'find  /opt/code/github/jumpscale/core9/cmds -exec ln -s {} "/usr/local/bin/" \;'


### PR DESCRIPTION
#### What this PR resolves:
Fix installing core9  by runninng install.sh instead of pip only to install build-essentials and python3-dev

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
