### PR TITLE
add reset option to js9_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ js9_start
 
 `js9_start` allows you to control the name of the container with the `-n` option (default name is `js9`), and the SSH port with the `-p` option (default port is 2222).
 
+`js9_start` will start a new container based on the local image if there isn't a js9 container on the system. If there is the user will be prompted to choose between using the existing container or removing the container and a new one would be created. To bypass the prompt you can choose the `r` option to reset the installation or `c` option to continue using the existing container.
+
 `js9_start` will start a new container based on the local image. If it doesn't find any local image, it downloads one from Docker Hub. With the `-b` option you instruct `js9_start` to first build a new image, which then always includes AYS, prefab and some extra libraries, but excluding the portal framework. If you want to rebuild the image that includes the portal framework, you need to you `js9_build` with the `-p` option.
 
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ js9_start
 
 `js9_start` allows you to control the name of the container with the `-n` option (default name is `js9`), and the SSH port with the `-p` option (default port is 2222).
 
-`js9_start` will start a new container based on the local image if there isn't a js9 container on the system. If there is the user will be prompted to choose between using the existing container or removing the container and a new one would be created. To bypass the prompt you can choose the `r` option to reset the installation or `c` option to continue using the existing container.
+`js9_start` will start a new container based on the local image if there isn't a js9 container on the system. If there is, the user will be prompted to choose between using the existing container or removing the container and a new one would be created. To bypass the prompt you can choose the `-r` option to reset the installation or `-c` option to continue using the existing container.
 
 `js9_start` will start a new container based on the local image. If it doesn't find any local image, it downloads one from Docker Hub. With the `-b` option you instruct `js9_start` to first build a new image, which then always includes AYS, prefab and some extra libraries, but excluding the portal framework. If you want to rebuild the image that includes the portal framework, you need to you `js9_build` with the `-p` option.
 

--- a/docs/js9_start.md
+++ b/docs/js9_start.md
@@ -1,0 +1,25 @@
+## Usage
+
+After finishing the building step, this command will actually start the container containing the js9 installation. To be able to use this command you need to source '.jsenv' file and have your `GIGDIR` environment variable exported to the location specified in the installation.
+
+By default the created container will be called 'js9' and will use port 2222. It is possible to specify the name and the port by using the various options available to this command specified below.
+
+If a js9 container already exists the user will be prompted to choose between starting the existing container or creating a new one and deleting the old container.
+
+## Command options
+
+The available options are:
+
+```
+-n name of container
+-p port on which to install
+-b build the docker, don't download from docker
+-r reset docker, destroy first if already on host
+-c continue using existing js9 docker
+-h help
+```
+- `n` specifies name of container. Default is 'js9'.
+- 'p' specifies the port used.
+- The `-b` option will remove the existing image and will rebuild a new image(which includes ays, prefab and additional libraries).
+- The `-r` option will remove the existing js9 docker and create a new container with same specified name and port.
+- The `-c` option will start the js9 container that is already in the system.

--- a/docs/js9_start.md
+++ b/docs/js9_start.md
@@ -1,6 +1,6 @@
 ## Usage
 
-After finishing the building step, this command will actually start the container containing the js9 installation. To be able to use this command you need to source '.jsenv' file and have your `GIGDIR` environment variable exported to the location specified in the installation.
+After finishing the building step, this command will actually start the container containing the js9 installation. To be able to use this command you need to source '.jsenv.sh' file and have your `GIGDIR` environment variable exported to the location specified in the installation.
 
 By default the created container will be called 'js9' and will use port 2222. It is possible to specify the name and the port by using the various options available to this command specified below.
 
@@ -18,8 +18,8 @@ The available options are:
 -c continue using existing js9 docker
 -h help
 ```
-- `n` specifies name of container. Default is 'js9'.
-- 'p' specifies the port used.
+- `-n` specifies name of container. Default is 'js9'.
+- `-p` specifies the port used.
 - The `-b` option will remove the existing image and will rebuild a new image(which includes ays, prefab and additional libraries).
 - The `-r` option will remove the existing js9 docker and create a new container with same specified name and port.
 - The `-c` option will start the js9 container that is already in the system.

--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -34,25 +34,20 @@ dockerrun() {
     bname="$1"
     iname="$2"
     port="${3:-2222}"
-    local addarg="${4:-}"
+    reset="$4"
+    local addarg="${5:-}"
 
     #addarg: -p 10700-10800:10700-10800
 
     echo "[+] start docker $bname -> $iname (port:$port)"
 
     existing="$(docker ps -aq -f name=^/${iname}$)"
-
-    if [[ ! -z "$existing" ]]; then
-        dockerremove $iname
-    fi
-
     mounted_volumes="\
         -v ${GIGDIR}/:/root/gig/ \
         -v ${GIGDIR}/code/:/opt/code/ \
         -v ${GIGDIR}/private/:/optvar/private \
         -v ${HOME}/.cache/pip/:/root/.cache/pip/ \
     "
-
     # mount optvar/data to all platforms except for windows to avoid fsync mongodb error
     # related: https://docs.mongodb.com/manual/administration/production-notes/#fsync-on-directories
     if [ -e /proc/version ] &&  ! grep -q Microsoft /proc/version; then
@@ -61,15 +56,28 @@ dockerrun() {
         "
     fi
 
-    docker run --name $iname \
-        --hostname $iname \
-        -d \
-        -p ${port}:22 ${addarg} \
-        --device=/dev/net/tun \
-        --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
-        --cap-add=DAC_OVERRIDE --cap-add=DAC_READ_SEARCH \
-        ${mounted_volumes} \
-        $bname > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
+    if [[ ! -z "$existing" ]]; then
+      if [ ! -z "$reset" ]; then
+        echo $reset
+        docker start $iname  > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
+      else
+        dockerremove $iname
+      fi
+    else
+        docker run --name $iname \
+            --hostname $iname \
+            -d \
+            -p ${port}:22 ${addarg} \
+            --device=/dev/net/tun \
+            --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
+            --cap-add=DAC_OVERRIDE --cap-add=DAC_READ_SEARCH \
+            -v ${GIGDIR}/:/root/gig/ \
+            -v ${GIGDIR}/code/:/opt/code/ \
+            -v ${GIGDIR}/data/:/optvar/data \
+            -v ${GIGDIR}/private/:/optvar/private \
+            $bname > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
+    fi
+
 
     sleep 1
 

--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -58,7 +58,6 @@ dockerrun() {
 
     if [[ ! -z "$existing" ]]; then
       if [ ! -z "$reset" ]; then
-        echo $reset
         docker start $iname  > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
       else
         dockerremove $iname

--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -34,7 +34,7 @@ dockerrun() {
     bname="$1"
     iname="$2"
     port="${3:-2222}"
-    reset="$4"
+    start="$4"
     local addarg="${5:-}"
 
     #addarg: -p 10700-10800:10700-10800
@@ -57,26 +57,22 @@ dockerrun() {
     fi
 
     if [[ ! -z "$existing" ]]; then
-      if [ ! -z "$reset" ]; then
+      if [ ! -z "$start" ]; then
         docker start $iname  > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
+        return
       else
         dockerremove $iname
       fi
-    else
-        docker run --name $iname \
-            --hostname $iname \
-            -d \
-            -p ${port}:22 ${addarg} \
-            --device=/dev/net/tun \
-            --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
-            --cap-add=DAC_OVERRIDE --cap-add=DAC_READ_SEARCH \
-            -v ${GIGDIR}/:/root/gig/ \
-            -v ${GIGDIR}/code/:/opt/code/ \
-            -v ${GIGDIR}/data/:/optvar/data \
-            -v ${GIGDIR}/private/:/optvar/private \
-            $bname > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
     fi
-
+    docker run --name $iname \
+        --hostname $iname \
+        -d \
+        -p ${port}:22 ${addarg} \
+        --device=/dev/net/tun \
+        --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
+        --cap-add=DAC_OVERRIDE --cap-add=DAC_READ_SEARCH \
+        ${mounted_volumes} \
+        $bname > ${logfile} 2>&1 || die "docker could not start, please check ${logfile}"
 
     sleep 1
 

--- a/scripts9/js_start_js9.sh
+++ b/scripts9/js_start_js9.sh
@@ -82,7 +82,7 @@ fi
 
 echo "[+] starting jumpscale9 development environment"
 
-dockerrun $bname $iname $port reset
+dockerrun $bname $iname $port js9_start
 
 # echo "* update jumpscale code (js9_code update -a jumpscale -f )"
 # ssh -A root@localhost -p ${port} 'export LC_ALL=C.UTF-8;export LANG=C.UTF-8;js9_code update -a jumpscale -f'


### PR DESCRIPTION
#### What this PR resolves:
Adding option to keep using old container when running js9_start

#### Changes proposed in this PR:

- User is prompted if the js9 docker exists on whether he would like to reset the installation
-Added option to reset or use same container


**Version**: 

**Fixes**: #68
