### PR TITLE
Fix sed, loading keys in OSX and Windows

### DIFF
--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -146,7 +146,12 @@ ssh_authorize() {
 
     echo "[+] authorizing local ssh keys on docker: $1"
     SSHKEYS=$(ssh-add -L)
-    docker exec -t "$1" /bin/sh -c "echo ${SSHKEYS} >> /root/.ssh/authorized_keys"
+    if [ -e /proc/version ] && grep -q Microsoft /proc/version; then
+        # Windows Sub Linux doesn't support escaping quote so ssh-add -L should have only one key
+        docker exec -t "$1" /bin/sh -c "echo ${SSHKEYS} >> /root/.ssh/authorized_keys"
+    else
+        docker exec -t "$1" /bin/sh -c "echo \"${SSHKEYS}\" >> /root/.ssh/authorized_keys"
+    fi
 }
 
 #

--- a/jsinit.sh
+++ b/jsinit.sh
@@ -146,7 +146,13 @@ main() {
 
     echo "[+] downloading generic environment file"
     curl -s https://raw.githubusercontent.com/Jumpscale/developer/$GIGDEVELOPERBRANCH/jsenv.sh?$RANDOM > ~/.jsenv.sh
-    sed -i "/export JSENV/a export GIGDIR='${GIGDIR}'" ~/.jsenv.sh
+    if [ "$(uname)" = "Darwin" ]; then
+        # OSX sed isn't standard so we need to use its syntax
+        sed -i '' '/export JSENV/a\
+export GIGDIR="'${GIGDIR}'"' ~/.jsenv.sh
+    else
+        sed -i "/export JSENV/a export GIGDIR='${GIGDIR}'" ~/.jsenv.sh
+    fi
     curl -s https://raw.githubusercontent.com/Jumpscale/developer/$GIGDEVELOPERBRANCH/jsenv-functions.sh?$RANDOM > /tmp/.jsenv-functions.sh
     . /tmp/.jsenv-functions.sh
 

--- a/scripts9/js_builder_base9.sh
+++ b/scripts9/js_builder_base9.sh
@@ -135,10 +135,6 @@ installzerotier() {
     container "apt-get install gpgv2 -y"
     container "curl -s 'https://pgp.mit.edu/pks/lookup?op=get&search=0x1657198823E52A61' | gpg --import"
     container "curl -s https://install.zerotier.com/ | bash || true"
-    # Due to permission changes in OSX Docker + Lowering privileges in zerotier, we need to manually set permissions for tun module
-    if [ "$(uname)" = "Darwin" ]; then
-        container "chmod 666 /dev/net/tun"
-    fi
 }
 
 cleanup() {

--- a/scripts9/js_start_js9.sh
+++ b/scripts9/js_start_js9.sh
@@ -84,6 +84,11 @@ echo "[+] starting jumpscale9 development environment"
 
 dockerrun $bname $iname $port js9_start
 
+# Due to permission changes in OSX Docker + Lowering privileges in zerotier, we need to manually set permissions for tun module
+if [ "$(uname)" = "Darwin" ]; then
+    container "chmod 666 /dev/net/tun"
+fi
+
 # echo "* update jumpscale code (js9_code update -a jumpscale -f )"
 # ssh -A root@localhost -p ${port} 'export LC_ALL=C.UTF-8;export LANG=C.UTF-8;js9_code update -a jumpscale -f'
 echo "* init js9 environment (js9_init)"


### PR DESCRIPTION
#### What this PR resolves:
The error for sed command on OSX and set the permissions for TUN device after starting the container not with installing zerotier

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
