### PR TITLE
clean up sharing the pip cache directory

### DIFF
--- a/jsenv-functions.sh
+++ b/jsenv-functions.sh
@@ -46,7 +46,6 @@ dockerrun() {
         -v ${GIGDIR}/:/root/gig/ \
         -v ${GIGDIR}/code/:/opt/code/ \
         -v ${GIGDIR}/private/:/optvar/private \
-        -v ${HOME}/.cache/pip/:/root/.cache/pip/ \
     "
     # mount optvar/data to all platforms except for windows to avoid fsync mongodb error
     # related: https://docs.mongodb.com/manual/administration/production-notes/#fsync-on-directories


### PR DESCRIPTION
#### What this PR resolves:
We used to share the pip cache directory between the host home directory and the root user pip cache directory on the container. This might not work on all platforms and not very clean to have in production.

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
