### PR TITLE
Fix building base image #90

### DIFF
--- a/scripts9/js_builder_base9.sh
+++ b/scripts9/js_builder_base9.sh
@@ -60,6 +60,7 @@ base_deps() {
     echo "[+]   setting up default environment"
     container 'echo "" > /etc/motd'
     container touch /root/.iscontainer
+    container mkdir /host
     echo "[+]   base deps done"
 
 }
@@ -126,7 +127,6 @@ installjs9() {
     container rm -rf /usr/local/bin/cmds_guest
 
     echo "[+]   initializing jumpscale part3"
-    container 'python3 -c "from JumpScale9 import j; j.do.initEnv()"'
     container 'python3 -c "from JumpScale9 import j; j.tools.jsloader.generate()"'
 
 }


### PR DESCRIPTION
#### What this PR resolves:


#### Changes proposed in this PR:

- Create /host directory with .iscontainer file at `setting up default environment ` step
- remove unneeded call to initEnv as it is already called with installing core9  


**Version**: 

**Fixes**: #90 
